### PR TITLE
Fix maintainer field in DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -4,7 +4,7 @@ Title: Implements PRELES model to be called from R
 Version: 1.0
 Date: 2013-04-25
 Author: Mikko Peltoniemi <mikko.peltoniemi@metla.fi>
-Maintainer: <mikko.peltoniemi@metla.fi>
+Maintainer: Mikko Peltoniemi <mikko.peltoniemi@metla.fi>
 Description: Awaiting manuscript decision
 License: What Licence is it under ?
 Depends:


### PR DESCRIPTION
The missing name in the maintainer field in DESCRIPTION is causing build errors for r-universe: https://github.com/PecanProject/universe/issues/2